### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Contactsegment/Form/Segment.php
+++ b/CRM/Contactsegment/Form/Segment.php
@@ -275,7 +275,7 @@ class CRM_Contactsegment_Form_Segment extends CRM_Core_Form {
     $parentParams = array('id' => $parentId, 'return' => 'label');
     try {
       return civicrm_api3('Segment', 'Getvalue', $parentParams);
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       return "";
     }
   }

--- a/CRM/Contactsegment/Page/Segment.php
+++ b/CRM/Contactsegment/Page/Segment.php
@@ -48,7 +48,7 @@ class CRM_Contactsegment_Page_Segment extends CRM_Core_Page {
         $row['type'] = $this->_segmentSetting['child_label'];
         try {
           $row['parent'] = civicrm_api3('Segment', 'Getvalue', array('id' => $daoSegments->parent_id, 'return' => 'label'));
-        } catch (CiviCRM_API3_Exception $ex) {
+        } catch (CRM_Core_Exception $ex) {
           $row['parent'] = '';
         }
       }

--- a/CRM/Contactsegment/Utils.php
+++ b/CRM/Contactsegment/Utils.php
@@ -21,12 +21,12 @@ class CRM_Contactsegment_Utils {
       foreach ($optionValues['values'] as $optionValueId => $optionValue) {
         try {
           civicrm_api3('OptionValue', 'Delete', array('id' => $optionValueId));
-        } catch (CiviCRM_API3_Exception $ex) {}
+        } catch (CRM_Core_Exception $ex) {}
       }
-    } catch (CiviCRM_API3_Exception $ex) {}
+    } catch (CRM_Core_Exception $ex) {}
     try {
       civicrm_api3('OptionGroup', 'Delete', array('id' => $optionGroupId));
-    } catch (CiviCRM_API3_Exception $ex) {}
+    } catch (CRM_Core_Exception $ex) {}
   }
 
   /**
@@ -47,7 +47,7 @@ class CRM_Contactsegment_Utils {
     }
     try {
       return civicrm_api3('OptionValue', 'Create', $params);
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       return FALSE;
     }
   }
@@ -68,7 +68,7 @@ class CRM_Contactsegment_Utils {
       'return' => 'id');
     try {
       return civicrm_api3('OptionValue', 'Getvalue', $params);
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       return FALSE;
     }
   }
@@ -87,7 +87,7 @@ class CRM_Contactsegment_Utils {
     }
     try {
       return civicrm_api3('OptionGroup', 'Getsingle', array('name' => $optionGroupName));
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       return FALSE;
     }
   }
@@ -112,7 +112,7 @@ class CRM_Contactsegment_Utils {
     }
     try {
      return civicrm_api3('OptionGroup', 'Create', $params);
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       return FALSE;
     }
   }
@@ -165,7 +165,7 @@ class CRM_Contactsegment_Utils {
    *
    * @param $roleLabel
    * @return string
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   public static function getRoleNameWithLabel($roleLabel) {
     $config = CRM_Contactsegment_Config::singleton();
@@ -182,7 +182,7 @@ class CRM_Contactsegment_Utils {
    *
    * @param $roleValue
    * @return array
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   public static function getRoleLabel($roleValue) {
     $config = CRM_Contactsegment_Config::singleton();
@@ -198,7 +198,7 @@ class CRM_Contactsegment_Utils {
    * Method to get list of possible roles for a segment
    *
    * @return array
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    *
    */
   public static function getRoleList() {
@@ -219,7 +219,7 @@ class CRM_Contactsegment_Utils {
    * Method to get list of segment parents
    *
    * @return array
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   public static function getParentList() {
     $parentList = array();
@@ -338,7 +338,7 @@ class CRM_Contactsegment_Utils {
           }
         }
       }
-    } catch (CiviCRM_API3_Exception $ex) {
+    } catch (CRM_Core_Exception $ex) {
       return FALSE;
     }
     return FALSE;

--- a/api/v3/ContactSegment/Create.php
+++ b/api/v3/ContactSegment/Create.php
@@ -50,7 +50,7 @@ function _civicrm_api3_contact_segment_create_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_contact_segment_create($params) {
   return civicrm_api3_create_success(CRM_Contactsegment_BAO_ContactSegment::add($params), $params, 'ContactSegment', 'Create');

--- a/api/v3/ContactSegment/Delete.php
+++ b/api/v3/ContactSegment/Delete.php
@@ -19,13 +19,13 @@ function _civicrm_api3_contact_segment_delete_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_contact_segment_delete($params) {
   if (array_key_exists('id', $params)) {
     return civicrm_api3_create_success(CRM_Contactsegment_BAO_ContactSegment::deleteWithId($params['id']), $params, 'ContactSegment', 'Delete');
   } else {
-    throw new API_Exception('Id is a mandatory param when deleting a contact segment', 'mandatory_id_missing', 0020);
+    throw new CRM_Core_Exception('Id is a mandatory param when deleting a contact segment', 'mandatory_id_missing', 0020);
   }
 }
 

--- a/api/v3/ContactSegment/Disable.php
+++ b/api/v3/ContactSegment/Disable.php
@@ -8,7 +8,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_contact_segment_disable($params) {
   $sql = "SELECT id, segment_id, contact_id FROM civicrm_contact_segment WHERE end_date <= CURDATE() AND is_active = %1";

--- a/api/v3/ContactSegment/Get.php
+++ b/api/v3/ContactSegment/Get.php
@@ -53,7 +53,7 @@ function _civicrm_api3_contact_segment_get_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_contact_segment_get($params) {
   return civicrm_api3_create_success(CRM_Contactsegment_BAO_ContactSegment::getValues($params), $params, 'ContactSegment', 'Get');

--- a/api/v3/Segment/Create.php
+++ b/api/v3/Segment/Create.php
@@ -38,7 +38,7 @@ function _civicrm_api3_segment_create_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_segment_create($params) {
   return civicrm_api3_create_success(CRM_Contactsegment_BAO_Segment::add($params), $params, 'Segment', 'Create');

--- a/api/v3/Segment/Delete.php
+++ b/api/v3/Segment/Delete.php
@@ -19,13 +19,13 @@ function _civicrm_api3_segment_delete_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_segment_delete($params) {
   if (array_key_exists('id', $params)) {
     return civicrm_api3_create_success(CRM_Contactsegment_BAO_Segment::deleteById($params['id']), $params, 'Segment', 'Delete');
   } else {
-    throw new API_Exception('Id is a mandatory param when deleting a segment', 'mandatory_id_missing', 0010);
+    throw new CRM_Core_Exception('Id is a mandatory param when deleting a segment', 'mandatory_id_missing', 0010);
   }
 }
 

--- a/api/v3/Segment/Get.php
+++ b/api/v3/Segment/Get.php
@@ -38,7 +38,7 @@ function _civicrm_api3_segment_get_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_segment_get($params) {
   return civicrm_api3_create_success(CRM_Contactsegment_BAO_Segment::getValues($params), $params, 'Segment', 'Get');

--- a/api/v3/SegmentSetting/Create.php
+++ b/api/v3/SegmentSetting/Create.php
@@ -38,7 +38,7 @@ function _civicrm_api3_segment_setting_create_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_segment_setting_create($params) {
   $segmentSetting = new CRM_Contactsegment_BAO_SegmentSetting();

--- a/api/v3/SegmentSetting/Get.php
+++ b/api/v3/SegmentSetting/Get.php
@@ -38,7 +38,7 @@ function _civicrm_api3_segment_setting_get_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  * {@getfields segment_setting}
  */
 function civicrm_api3_segment_setting_get($params) {


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.